### PR TITLE
Multilayer annotation, save labels and generate metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ We have already **extended** SAM's click-based foreground separation to full **c
 
 At last, our SAM integration supports both **2D and 3D images**!
 
+This fork improves the 3D annotation workflow, allows for reading in 
+precomputed embeddings and generates metric outputs.
+
+**NOTE: this fork is under active development and has not be thoroughly 
+tested on various images formats. It likely has 
+many bugs - 
+please submit an issue if you encounter any.**
+
 ----------------------------------
 
 Everything mode             |  Click-based semantic segmentation mode |  Click-based instance segmentation mode

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     tqdm
     napari-nifti
     superqt
+    tifffile
     # git+https://github.com/facebookresearch/segment-anything.git@main
 
 python_requires = >=3.8

--- a/src/napari_sam/_widget.py
+++ b/src/napari_sam/_widget.py
@@ -70,7 +70,7 @@ class SamManager():  ##TODO Makes this outside class
         self.z_stack_id = samwidget.viewer.dims.current_step[0] // self.max_z_in_stack
         z = self.z(samwidget)
         embedding_fname = f"{self.image_basename}_zmax{self.max_z_in_stack}-zstack{self.z_stack_id}.pt"
-        embedding_fp = samwidget.le_embedding_fp.strip()
+        embedding_fp = samwidget.le_embedding_fp.text().strip()
         presaved = os.path.join(embedding_fp, embedding_fname)
 
         if os.path.exists(presaved):
@@ -120,6 +120,7 @@ class SamManager():  ##TODO Makes this outside class
                 l_creating_features.deleteLater()
 
     def check_set(self, samwidget):
+        # TODO handle when image has no source path as generated from inside console...
         samwidget_image_basename = os.path.splitext(os.path.basename(samwidget.image_layer.source.path))[0]
         if samwidget_image_basename != self.image_basename:
             self.generate_embedding(samwidget, samwidget_image_basename)
@@ -489,6 +490,11 @@ class SamWidget(QWidget):
         metadata_fp = self.le_metadata_fp.text().strip()
         image_layer = self.viewer.layers[image_layer_name]
         path = image_layer.source.path
+
+        # no path found for image
+        if path is None:
+            return
+        
         image_name = os.path.basename(path)
 
         # if metadata record already read in, do not read again

--- a/src/napari_sam/_widget.py
+++ b/src/napari_sam/_widget.py
@@ -56,7 +56,7 @@ class SamManager():  ##TODO Makes this outside class
         self.channels = None
         self.z_stack_id = None
         self.max_z_in_stack = 100
-        self.embedding_fp = r'G:\Group-Little_MCRI\People\Thanushi\projects\annotation-tool\SAM pipeline\SAM embeddings'
+        self.embedding_fp = r'G:\Group-Little_MCRI\People\Thanushi\projects\annotation-tool\SAM_pipeline\SAM_embeddings'
         self.features = None
         self.model = None
         self.predictor = None
@@ -72,6 +72,7 @@ class SamManager():  ##TODO Makes this outside class
         z = self.z(samwidget)
         embedding_fname = f"{self.image_basename}_zmax{self.max_z_in_stack}-zstack{self.z_stack_id}.pt"
         presaved = os.path.join(self.embedding_fp, embedding_fname)
+        print("checking presaved", presaved)
         if os.path.exists(presaved):
             print("  using presaved")
             self.features = torch.load(presaved,
@@ -348,8 +349,6 @@ class SamWidget(QWidget):
         self.bbox_edge_width = 10
         self.le_bbox_edge_width.setText(str(self.bbox_edge_width))
 
-
-
         self.init_comboboxes()
         self.sam = SamManager()
         self.viewer.layers.selection.events.active.connect(self._select_labels_layer)
@@ -364,22 +363,24 @@ class SamWidget(QWidget):
 
     def _select_labels_layer(self):
         """
-        Triggered whenever different layer is selected. If it's a labels layer, will
-        change the widget labels layer for model input.
+        Triggered whenever different layer is selected. If it's a labels layer
+        and model is currently active, will change the widget labels layer
+        for model input.
         :return:
         """
         current_layer = self.viewer.layers.selection.active
         if isinstance(current_layer, napari.layers.Labels) and \
                 (current_layer.name != self.cb_label_layers.currentText()):
-            # deactivate if active
             if self.is_active:
                 self._deactivate()
-            # switch output to that labels layer
-            self.cb_label_layers.setCurrentText(current_layer.name)
+                # switch output to that labels layer
+                self.cb_label_layers.setCurrentText(current_layer.name)
+                self._activate()
 
             # activate if not yet active and not adding initial set of layers
-            if (not self.is_active) and (not self.adding_multiple_labels):
-                self._activate()
+            elif (not self.is_active) and (not self.adding_multiple_labels):
+                self.cb_label_layers.setCurrentText(current_layer.name)
+            #    self._activate()
 
     def select_layer_while_active(self, layer):
         """


### PR DESCRIPTION
New features include
- Button to Load annotations that will load any existing annotation (saved to same filepath as image currently opened) or generate empty labels matching labels specified in settings if none are available. Load model button will also search for and load any existing annotation first.
- Warning is output once only if no matching metadata is found for image
- Settings tab will now cache based on previous inputs
- Settings enables ability to add metrics to calculate area of each segmentation as a percentage of another label (with option to choose specific paint number within that labels layer)
- Able to list labels layers with "-" to signify semantic segmentation e.g. "graft-host" indicates that label 1 = graft annotation, label 2 = host. WARNING: "-" should not be used in other contexts